### PR TITLE
coral-boot-script: Use UNPACKDIR instead of WORKDIR

### DIFF
--- a/recipes-bsp/coral-boot-script/coral-boot-script.bb
+++ b/recipes-bsp/coral-boot-script/coral-boot-script.bb
@@ -9,7 +9,7 @@ INHIBIT_DEFAULT_DEPS = "1"
 SRC_URI = "file://boot.txt"
 
 do_compile() {
-    mkimage -A arm -T script -C none -n "Boot script" -d "${WORKDIR}/boot.txt" boot.scr
+    mkimage -A arm -T script -C none -n "Boot script" -d "${UNPACKDIR}/boot.txt" boot.scr
 }
 
 inherit deploy nopackages


### PR DESCRIPTION
Update for UNPACKDIR transition