### PR TITLE
linux-coral: Added "Upstream-Status: Inactive-Upstream" to all linux-coral-5.4 patches

### DIFF
--- a/recipes-kernel/linux/linux-coral-5.4/0001-regulator-bd718x7-Add-MODULE_ALIAS.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0001-regulator-bd718x7-Add-MODULE_ALIAS.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 754c063fa38f0d4535e8d022f895e385728ca846 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Guido=20G=C3=BCnther?= <agx@sigxcpu.org>
 Date: Mon, 30 Sep 2019 22:26:00 +0200

--- a/recipes-kernel/linux/linux-coral-5.4/0002-regulator-bd718x7-Simplify-the-code-by-removing-stru.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0002-regulator-bd718x7-Simplify-the-code-by-removing-stru.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 28e6442b240279af714dbfd0144b2f5e8cbc2b6a Mon Sep 17 00:00:00 2001
 From: Axel Lin <axel.lin@ingics.com>
 Date: Wed, 8 Jan 2020 09:42:55 +0800

--- a/recipes-kernel/linux/linux-coral-5.4/0003-mfd-Rohm-PMICs-Use-platform_device_id-to-match-MFD-s.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0003-mfd-Rohm-PMICs-Use-platform_device_id-to-match-MFD-s.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 998dc427dbb50c81f2a588667bff4a1328460c24 Mon Sep 17 00:00:00 2001
 From: Matti Vaittinen <matti.vaittinen@fi.rohmeurope.com>
 Date: Mon, 20 Jan 2020 15:42:38 +0200

--- a/recipes-kernel/linux/linux-coral-5.4/0004-regulator-bd718x7-Split-driver-to-common-and-bd718x7.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0004-regulator-bd718x7-Split-driver-to-common-and-bd718x7.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 46e726b6717847da205dccaf883d73fa1565f7d1 Mon Sep 17 00:00:00 2001
 From: Matti Vaittinen <matti.vaittinen@fi.rohmeurope.com>
 Date: Mon, 20 Jan 2020 15:44:45 +0200

--- a/recipes-kernel/linux/linux-coral-5.4/0005-regulator-bd718x7-remove-voltage-change-restriction-.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0005-regulator-bd718x7-remove-voltage-change-restriction-.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From f46b9d18f4fb8588c6048b8024523e012424d914 Mon Sep 17 00:00:00 2001
 From: Matti Vaittinen <matti.vaittinen@fi.rohmeurope.com>
 Date: Wed, 13 May 2020 17:39:21 +0300

--- a/recipes-kernel/linux/linux-coral-5.4/0006-arm64-dts-freescale-add-initial-support-for-Google-i.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0006-arm64-dts-freescale-add-initial-support-for-Google-i.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From ca22043e293c06fb9ec120304e963047c49c7ece Mon Sep 17 00:00:00 2001
 From: Marco Antonio Franchi <marco.franchi@nxp.com>
 Date: Tue, 17 Dec 2019 13:36:17 +0000

--- a/recipes-kernel/linux/linux-coral-5.4/0007-arm64-dts-imx8mq-phanbell-Add-support-for-ethernet.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0007-arm64-dts-imx8mq-phanbell-Add-support-for-ethernet.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 9cf62eac95c7392a0075722c1bf5cdbfdd4393e4 Mon Sep 17 00:00:00 2001
 From: Alifer Moraes <alifer.wsdm@gmail.com>
 Date: Tue, 11 Feb 2020 10:48:28 -0300

--- a/recipes-kernel/linux/linux-coral-5.4/0008-arm64-dts-imx8mq-phanbell-Add-gpio-fan-thermal-suppo.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0008-arm64-dts-imx8mq-phanbell-Add-gpio-fan-thermal-suppo.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From ee0824e83cf33f393a716fb5d93e877b9e430dd2 Mon Sep 17 00:00:00 2001
 From: Vitor Massaru Iha <vitor@massaru.org>
 Date: Mon, 2 Mar 2020 22:15:16 -0300

--- a/recipes-kernel/linux/linux-coral-5.4/0009-arm64-dts-imx8mq-phanbell-Fix-Ethernet-PHY-post-rese.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0009-arm64-dts-imx8mq-phanbell-Fix-Ethernet-PHY-post-rese.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From f1eacbecb579c548724704c740848da19dffc5b6 Mon Sep 17 00:00:00 2001
 From: Alifer Moraes <alifer.wsdm@gmail.com>
 Date: Fri, 6 Mar 2020 07:42:19 -0300

--- a/recipes-kernel/linux/linux-coral-5.4/0010-arm64-dts-imx8mq-phanbell-Replace-deprecated-phy-res.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0010-arm64-dts-imx8mq-phanbell-Replace-deprecated-phy-res.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 5df89084e49729eafa4eb8b7833674668086cf15 Mon Sep 17 00:00:00 2001
 From: Krzysztof Kozlowski <krzk@kernel.org>
 Date: Sun, 23 Aug 2020 13:15:06 +0200

--- a/recipes-kernel/linux/linux-coral-5.4/0011-arm64-dts-imx8mq-phanbell-Align-pin-configuration-gr.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0011-arm64-dts-imx8mq-phanbell-Align-pin-configuration-gr.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From d7cc3d71a65a2f611efb98ed0c39f85b3d5263f6 Mon Sep 17 00:00:00 2001
 From: Krzysztof Kozlowski <krzk@kernel.org>
 Date: Fri, 28 Aug 2020 18:47:46 +0200

--- a/recipes-kernel/linux/linux-coral-5.4/0012-arm64-dts-imx8mq-phanbell-Disable-busfreq-to-avoid-s.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0012-arm64-dts-imx8mq-phanbell-Disable-busfreq-to-avoid-s.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 8d652338e1944cafff83e1470b64ebd6232b577c Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Thu, 22 Oct 2020 21:44:02 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0013-MLK-15307-2-clk-imx8mq-set-the-parent-clocks-of-PCIE.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0013-MLK-15307-2-clk-imx8mq-set-the-parent-clocks-of-PCIE.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From e645d6b386a83843a36608ba3be7f864dfc06a91 Mon Sep 17 00:00:00 2001
 From: Richard Zhu <hongxing.zhu@nxp.com>
 Date: Wed, 21 Jun 2017 10:23:00 +0800

--- a/recipes-kernel/linux/linux-coral-5.4/0014-arm64-dts-imx8mq-Set-ext_osc-to-1-as-default.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0014-arm64-dts-imx8mq-Set-ext_osc-to-1-as-default.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 02b389837fff9bee4a0221513e7185277fa4ca92 Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Mon, 9 Nov 2020 21:18:54 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0015-PCI-imx-Use-the-external-clock-as-REF_CLK-when-neede.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0015-PCI-imx-Use-the-external-clock-as-REF_CLK-when-neede.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From f933537c63c6140707b96463f0573bd75f9a3b23 Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Sun, 15 Nov 2020 22:39:01 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0016-PCI-imx-Provide-a-clock-to-the-device-for-i.MX8MQ.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0016-PCI-imx-Provide-a-clock-to-the-device-for-i.MX8MQ.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From a38acdc9ca4548e7d6afad9bde51a6cd6d2de619 Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Sun, 15 Nov 2020 22:45:53 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0017-arm64-dts-imx8mq-phanbell-Enable-PCIe.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0017-arm64-dts-imx8mq-phanbell-Enable-PCIe.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 300fb8ccf767c216e262cfc8e6efab2cce7e9b13 Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Thu, 5 Nov 2020 22:55:47 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0018-spi-spi-imx-Revive-cs-gpios-property-for-DT.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0018-spi-spi-imx-Revive-cs-gpios-property-for-DT.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 62ac8479d1a70e2c0ef04a06936e47987f04b180 Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Sat, 2 Jan 2021 19:49:34 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0019-arm64-dts-imx8mq-phanbell-Enable-ECSPI1.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0019-arm64-dts-imx8mq-phanbell-Enable-ECSPI1.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 40a8007cb59fefd4fc83c003742cf12cfae607ba Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Sat, 2 Jan 2021 19:55:05 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0020-arm64-dts-imx8mq-phanbell-Add-gpio-pinmux-for-40-pin.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0020-arm64-dts-imx8mq-phanbell-Add-gpio-pinmux-for-40-pin.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 71e58a267131a7ca719c647c7ec2be002010d5c6 Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Sat, 2 Jan 2021 19:56:43 +0900

--- a/recipes-kernel/linux/linux-coral-5.4/0021-arm64-dts-imx8mq-phanbell-Enable-I2C-2-I2C-3.patch
+++ b/recipes-kernel/linux/linux-coral-5.4/0021-arm64-dts-imx8mq-phanbell-Enable-I2C-2-I2C-3.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inactive-Upstream
+
 From 324a26744442949fab8aa9aeafe2bae25e9d5707 Mon Sep 17 00:00:00 2001
 From: Ryosuke Saito <rsaito@redhat.com>
 Date: Fri, 23 Apr 2021 19:20:57 +0900


### PR DESCRIPTION
Added "Upstream-Status: Inactive-Upstream" to all linux-coral-5.4 patches

"Upstream-Status" required for all patches for building with Yoe 2024.06